### PR TITLE
Use JenkinsLocationConfiguration to fetch the URL.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
   <name>Bitbucket Pullrequest Builder Plugin</name>
-  <version>1.4.4</version>
+  <version>1.4.5-SNAPSHOT</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</url>
-    <tag>bitbucket-pullrequest-builder-1.4.4</tag>
+    <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
   <name>Bitbucket Pullrequest Builder Plugin</name>
-  <version>1.4.3</version>
+  <version>1.4.4-SNAPSHOT</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</url>
-    <tag>bitbucket-pullrequest-builder-1.4.3</tag>
+    <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
   <name>Bitbucket Pullrequest Builder Plugin</name>
-  <version>1.4.3-SNAPSHOT</version>
+  <version>1.4.3</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</url>
-    <tag>HEAD</tag>
+    <tag>bitbucket-pullrequest-builder-1.4.3</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
   <name>Bitbucket Pullrequest Builder Plugin</name>
-  <version>1.4.4-SNAPSHOT</version>
+  <version>1.4.4</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>
@@ -17,7 +17,7 @@
     <connection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</url>
-    <tag>HEAD</tag>
+    <tag>bitbucket-pullrequest-builder-1.4.4</tag>
   </scm>
   <developers>
     <developer>


### PR DESCRIPTION
`Jenkins.getInstance().getRootUrl()` returns `null` despite the URL
being set through the web UI. `JenkinsLocationConfiguration.getUrl()`
returns the correct URL.

Thanks Esteban Angee on StackOverflow:
http://stackoverflow.com/questions/15949946/programatically-access-jenkins-url

[Resolves nishio-dens/bitbucket-pullrequest-builder-plugin#19]

Before/after showing my fix working:
![img](http://i.imgur.com/rrVMKFc.png)
