### PR TITLE
Development webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Jenkins plugin builds pull requests from Bitbucket.org and will report the 
 Prerequisites
 ================================
 
-- Jenkins 1.509.4 or higher.
+- Jenkins 1.580.1 or higher.
 - https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
 
 
@@ -21,17 +21,26 @@ Creating a Job
 - In Branch Specifier, type as bellow
   - */${sourceBranch}
 - Under Build Triggers, check Bitbucket Pull Request Builder
-- In Cron, enter crontab for this job.
-  - ex: * * * * *
 - In Bitbucket BasicAuth Username, write your bitbucket username like jenkins@densan-labs.net
 - In Bitbucket BasicAuth Password, write your password
 - Write RepositoryOwner
 - Write RepositoryName
 - Save to preserve your changes
 
+Configuiring Bitbucket
+======================
+
+ - Select "Settings" (gear icon) for the Bitbucket repository
+ - Click "Webhooks" under "Integrations"
+ - Click "Add webhook"
+ - In the URL blank, enter <JENKINS-URL>/bitbucket-pullrequest/ (for example https://my.jenkins-server.com/bitbucket-pullrequest/).  Do not forget the trailing slash!
+ - Under Triggers, choose "Choose from a full list of triggers."
+ - Select "Created" and "Updated" under "Pull Request."  If you want to use the feature "Rebuild if destination branch changes?" you must also check "Push" under "Repository/"
+
 Merge the Pull Request's Source Branch into the Target Branch Before Building
 ==============================================================================
 You may want Jenkins to attempt to merge your PR before doing the build -- this way it will find conflicts for you automatically.
+
 - Follow the steps above in "Creating a Job"
 - In the "Source Code Management" > "Git" > "Additional Behaviors" section, click "Add" > "Merge Before Building"
 - In "Name of Repository" put "origin" (or, if not using default name, use your remote repository's name. Note: unlike in the main part of the Git Repository config, you cannot leave this item blank for "default".)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.4</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.580.1</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>2.2.4</version>
+      <version>2.3.5</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -23,7 +23,6 @@ import java.util.logging.Logger;
 public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private static final Logger logger = Logger.getLogger(BitbucketBuildTrigger.class.getName());
     private final String projectPath;
-    private final String cron;
     private final String username;
     private final String password;
     private final String repositoryOwner;
@@ -40,7 +39,6 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     @DataBoundConstructor
     public BitbucketBuildTrigger(
             String projectPath,
-            String cron,
             String username,
             String password,
             String repositoryOwner,
@@ -48,10 +46,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String ciSkipPhrases,
             boolean checkDestinationCommit,
             boolean approveIfSuccess
-            ) throws ANTLRException {
-        super(cron);
+            ) {
         this.projectPath = projectPath;
-        this.cron = cron;
         this.username = username;
         this.password = password;
         this.repositoryOwner = repositoryOwner;
@@ -63,10 +59,6 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getProjectPath() {
         return this.projectPath;
-    }
-
-    public String getCron() {
-        return this.cron;
     }
 
     public String getUsername() {
@@ -143,21 +135,6 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             }
         }
         return values;
-    }
-
-    @Override
-    public void run() {
-        if(this.getBuilder().getProject().isDisabled()) {
-            logger.info("Build Skip.");
-        } else {
-            this.bitbucketPullRequestsBuilder.run();
-        }
-        this.getDescriptor().save();
-    }
-
-    @Override
-    public void stop() {
-        super.stop();
     }
 
     public static final class BitbucketBuildTriggerDescriptor extends TriggerDescriptor {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -1,6 +1,5 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
-import antlr.ANTLRException;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
@@ -23,17 +23,6 @@ public class BitbucketPullRequestsBuilder {
         return new BitbucketPullRequestsBuilder();
     }
 
-    public void stop() {
-        // TODO?
-    }
-
-    public void run() {
-        logger.info("Build Start.");
-        this.repository.init();
-        Collection<BitbucketPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
-        this.repository.addFutureBuildTasks(targetPullRequests);
-    }
-
     public void runPullRequestBuild(BitbucketPullRequestResponseValue pullRequest) {
         this.repository.init();
         this.repository.addFutureBuildTasks(Collections.singletonList(pullRequest));
@@ -43,7 +32,7 @@ public class BitbucketPullRequestsBuilder {
         if (this.project == null || this.trigger == null) {
             throw new IllegalStateException();
         }
-        this.repository = new BitbucketRepository(this.trigger.getProjectPath(), this);
+        this.repository = new BitbucketRepository(this);
         this.builds = new BitbucketBuilds(this.trigger, this.repository);
         return this;
     }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
@@ -3,7 +3,10 @@ package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValue;
 import hudson.model.AbstractProject;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 /**
@@ -29,6 +32,11 @@ public class BitbucketPullRequestsBuilder {
         this.repository.init();
         Collection<BitbucketPullRequestResponseValue> targetPullRequests = this.repository.getTargetPullRequests();
         this.repository.addFutureBuildTasks(targetPullRequests);
+    }
+
+    public void runPullRequestBuild(BitbucketPullRequestResponseValue pullRequest) {
+        this.repository.init();
+        this.repository.addFutureBuildTasks(Collections.singletonList(pullRequest));
     }
 
     public BitbucketPullRequestsBuilder setupBuilder() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
@@ -3,9 +3,6 @@ package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValue;
 import hudson.model.AbstractProject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Logger;
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -21,22 +21,16 @@ public class BitbucketRepository {
     public static final String BUILD_START_MARKER = "[*BuildStarted* **%s**] %s into %s";
     public static final String BUILD_FINISH_MARKER = "[*BuildFinished* **%s**] %s into %s";
 
-    public static final String BUILD_START_REGEX = "\\[\\*BuildStarted\\* \\*\\*%s\\*\\*\\] ([0-9a-fA-F]+) into ([0-9a-fA-F]+)";
-    public static final String BUILD_FINISH_REGEX = "\\[\\*BuildFinished\\* \\*\\*%s\\*\\*\\] ([0-9a-fA-F]+) into ([0-9a-fA-F]+)";
-
     public static final String BUILD_FINISH_SENTENCE = BUILD_FINISH_MARKER + " \n\n **%s** - %s";
-    public static final String BUILD_REQUEST_MARKER = "test this please";
 
     public static final String BUILD_SUCCESS_COMMENT =  "SUCCESS";
     public static final String BUILD_FAILURE_COMMENT = "FAILURE";
-    private String projectPath;
-    private BitbucketPullRequestsBuilder builder;
+    private final BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;
     private BitbucketApiClient client;
     private Boolean initialized = false;
 
-    public BitbucketRepository(String projectPath, BitbucketPullRequestsBuilder builder) {
-        this.projectPath = projectPath;
+    public BitbucketRepository(BitbucketPullRequestsBuilder builder) {
         this.builder = builder;
     }
 
@@ -50,18 +44,6 @@ public class BitbucketRepository {
                     trigger.getRepositoryName());
             initialized = true;
         }
-    }
-
-    public Collection<BitbucketPullRequestResponseValue> getTargetPullRequests() {
-        logger.info("Fetch PullRequests.");
-        List<BitbucketPullRequestResponseValue> pullRequests = client.getPullRequests();
-        List<BitbucketPullRequestResponseValue> targetPullRequests = new ArrayList<BitbucketPullRequestResponseValue>();
-        for(BitbucketPullRequestResponseValue pullRequest : pullRequests) {
-            if (isBuildTarget(pullRequest)) {
-                targetPullRequests.add(pullRequest);
-            }
-        }
-        return targetPullRequests;
     }
 
     public String postBuildStartCommentTo(BitbucketPullRequestResponseValue pullRequest) {
@@ -114,88 +96,5 @@ public class BitbucketRepository {
 
     public void postPullRequestApproval(String pullRequestId) {
         this.client.postPullRequestApproval(pullRequestId);
-    }
-
-    public boolean isBuildTarget(BitbucketPullRequestResponseValue pullRequest) {
-
-        boolean shouldBuild = true;
-        if (pullRequest.getState() != null && pullRequest.getState().equals("OPEN")) {
-            if (isSkipBuild(pullRequest.getTitle())) {
-                return false;
-            }
-
-            String sourceCommit = pullRequest.getSource().getCommit().getHash();
-
-            BitbucketPullRequestResponseValueRepository destination = pullRequest.getDestination();
-            String owner = destination.getRepository().getOwnerName();
-            String repositoryName = destination.getRepository().getRepositoryName();
-            String destinationCommit = destination.getCommit().getHash();
-
-            String id = pullRequest.getId();
-            List<BitbucketPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);
-
-            if (comments != null) {
-                Collections.sort(comments);
-                Collections.reverse(comments);
-                for (BitbucketPullRequestComment comment : comments) {
-                    String content = comment.getContent();
-                    if (content == null || content.isEmpty()) {
-                        continue;
-                    }
-
-                    //These will match any start or finish message -- need to check commits
-                    String project_build_start = String.format(BUILD_START_REGEX, builder.getProject().getDisplayName());
-                    String project_build_finished = String.format(BUILD_FINISH_REGEX, builder.getProject().getDisplayName());
-                    Matcher startMatcher = Pattern.compile(project_build_start, Pattern.CASE_INSENSITIVE).matcher(content);
-                    Matcher finishMatcher = Pattern.compile(project_build_finished, Pattern.CASE_INSENSITIVE).matcher(content);
-
-                    if (startMatcher.find() ||
-                        finishMatcher.find()) {
-
-                        String sourceCommitMatch;
-                        String destinationCommitMatch;
-
-                        if (startMatcher.find(0)) {
-                            sourceCommitMatch = startMatcher.group(1);
-                            destinationCommitMatch = startMatcher.group(2);
-                        } else {
-                            sourceCommitMatch = finishMatcher.group(1);
-                            destinationCommitMatch = finishMatcher.group(2);
-                        }
-
-                        //first check source commit -- if it doesn't match, just move on. If it does, investigate further.
-                        if (sourceCommitMatch.equalsIgnoreCase(sourceCommit)) {
-                            // if we're checking destination commits, and if this doesn't match, then move on.
-                            if (this.trigger.getCheckDestinationCommit()
-                                    && (!destinationCommitMatch.equalsIgnoreCase(destinationCommit))) {
-                            	continue;
-                            }
-
-                            shouldBuild = false;
-                            break;
-                        }
-                    }
-
-                    if (content.contains(BUILD_REQUEST_MARKER.toLowerCase())) {
-                        shouldBuild = true;
-                        break;
-                    }
-                }
-            }
-        }
-        return shouldBuild;
-    }
-
-    private boolean isSkipBuild(String pullRequestTitle) {
-        String skipPhrases = this.trigger.getCiSkipPhrases();
-        if (skipPhrases != null && !"".equals(skipPhrases)) {
-            String[] phrases = skipPhrases.split(",");
-            for(String phrase : phrases) {
-                if (pullRequestTitle.toLowerCase().contains(phrase.trim().toLowerCase())) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -33,6 +33,7 @@ public class BitbucketRepository {
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;
     private BitbucketApiClient client;
+    private Boolean initialized = false;
 
     public BitbucketRepository(String projectPath, BitbucketPullRequestsBuilder builder) {
         this.projectPath = projectPath;
@@ -40,12 +41,15 @@ public class BitbucketRepository {
     }
 
     public void init() {
-        trigger = this.builder.getTrigger();
-        client = new BitbucketApiClient(
-                trigger.getUsername(),
-                trigger.getPassword(),
-                trigger.getRepositoryOwner(),
-                trigger.getRepositoryName());
+        if (!initialized) {
+            trigger = this.builder.getTrigger();
+            client = new BitbucketApiClient(
+                    trigger.getUsername(),
+                    trigger.getPassword(),
+                    trigger.getRepositoryOwner(),
+                    trigger.getRepositoryName());
+            initialized = true;
+        }
     }
 
     public Collection<BitbucketPullRequestResponseValue> getTargetPullRequests() {
@@ -112,7 +116,7 @@ public class BitbucketRepository {
         this.client.postPullRequestApproval(pullRequestId);
     }
 
-    private boolean isBuildTarget(BitbucketPullRequestResponseValue pullRequest) {
+    public boolean isBuildTarget(BitbucketPullRequestResponseValue pullRequest) {
 
         boolean shouldBuild = true;
         if (pullRequest.getState() != null && pullRequest.getState().equals("OPEN")) {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -1,17 +1,11 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestComment;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValue;
-import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValueRepository;
+
+import java.util.Collection;
+import java.util.logging.Logger;
 
 /**
  * Created by nishio

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketWebhookListener.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketWebhookListener.java
@@ -1,7 +1,5 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
-import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketApiClient;
-import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponse;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValue;
 import hudson.Extension;
 import hudson.model.Job;
@@ -23,7 +21,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketWebhookListener.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketWebhookListener.java
@@ -1,0 +1,150 @@
+package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
+
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketApiClient;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponse;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValue;
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.UnprotectedRootAction;
+import hudson.scm.SCM;
+import hudson.triggers.Trigger;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.triggers.SCMTriggerItem;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.eclipse.jgit.transport.URIish;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class BitbucketWebhookListener  implements UnprotectedRootAction {
+    private final String BITBUCKET_HOOK_URL = "bitbucket-pullrequest";
+
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getDisplayName() {
+        return null;
+    }
+
+    public String getUrlName() {
+        return BITBUCKET_HOOK_URL;
+    }
+
+    public void doIndex(StaplerRequest req) throws IOException {
+        String body = IOUtils.toString(req.getInputStream());
+        if (!body.isEmpty() && req.getRequestURI().contains("/" + BITBUCKET_HOOK_URL)) {
+
+            String contentType = req.getContentType();
+
+            if (contentType != null && contentType.startsWith("application/x-www-form-urlencoded")) {
+                body = URLDecoder.decode(body);
+            }
+
+            if (body.startsWith("payload=")) {
+                body = body.substring(8);
+            }
+
+            LOGGER.log(Level.WARNING, "Received hook notification : {0}", body);
+
+            if (isPullRequestCreateOrUpdate(req)) {
+                JSONObject payload = JSONObject.fromObject(body);
+
+                triggerAppropriateBuild(req, payload);
+            }
+
+        } else {
+            LOGGER.log(Level.WARNING, "The Jenkins job cannot be triggered. You might not have configured the WebHook correctly on BitBucket !! `http://<JENKINS-URL>/bitbucket-pullrequest`");
+        }
+
+    }
+
+    private void triggerAppropriateBuild(HttpServletRequest req, JSONObject payload) {
+        try {
+            BitbucketPullRequestResponseValue pullRequest = createPullRequestFromJson(payload);
+
+            LOGGER.log(Level.FINE, "Parsed pull request: {0}", pullRequest.getDescription());
+
+            Collection<BitbucketBuildTrigger> matchingTriggers = findTriggersMatchingPullRequest(pullRequest);
+
+            for(BitbucketBuildTrigger trigger : matchingTriggers) {
+                trigger.getBuilder().runPullRequestBuild(pullRequest);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Could not parse JSON for pull request (" + e.getMessage() + "):\n" + payload.toString(4));
+        }
+    }
+
+    private Collection<BitbucketBuildTrigger> findTriggersMatchingPullRequest(BitbucketPullRequestResponseValue pullRequest) {
+        List<BitbucketBuildTrigger> triggers = new ArrayList<BitbucketBuildTrigger>();
+
+        for (Job<?,?> job : Jenkins.getInstance().getAllItems(Job.class)) {
+            if(repositoryMatches(pullRequest, job)) {
+                for (BitbucketBuildTrigger trigger : getBitBucketTriggers(job)) {
+                    triggers.add(trigger);
+                }
+            }
+        }
+
+        return triggers;
+    }
+
+    private Boolean repositoryMatches(BitbucketPullRequestResponseValue pullRequest, Job<?, ?> job) {
+//        SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
+//        List<SCM> scmTriggered = new ArrayList<SCM>();
+//        URIish gitRemote = new URIish(pullRequest.getDestination().getRepository().get)
+//        for (SCM scmTrigger : item.getSCMs()) {
+//
+//        }
+        return false;
+    }
+
+    private Collection<BitbucketBuildTrigger> getBitBucketTriggers(Job<?, ?> job) {
+        ArrayList<BitbucketBuildTrigger> triggers = new ArrayList<BitbucketBuildTrigger>();
+
+        if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
+            ParameterizedJobMixIn.ParameterizedJob pJob = (ParameterizedJobMixIn.ParameterizedJob) job;
+
+            for (Trigger trigger : pJob.getTriggers().values()) {
+                if (trigger instanceof BitbucketBuildTrigger) {
+                    triggers.add((BitbucketBuildTrigger) trigger);
+                }
+            }
+        }
+
+        LOGGER.log(Level.FINE, "Found {0} applicable triggers", triggers.size());
+
+        return triggers;
+    }
+
+    private BitbucketPullRequestResponseValue createPullRequestFromJson(JSONObject payload) throws IOException {
+        JSONObject pullRequestJson = payload.getJSONObject("pullrequest");
+
+        if (pullRequestJson == null) {
+            throw new IOException("Did not find pull request object in payload.");
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        BitbucketPullRequestResponseValue pullRequest = mapper.readValue(pullRequestJson.toString(), BitbucketPullRequestResponseValue.class);
+        return pullRequest;
+    }
+
+    private static boolean isPullRequestCreateOrUpdate(HttpServletRequest req) {
+        return req.getHeader("User-Agent").equalsIgnoreCase("Bitbucket-Webhooks/2.0") &&
+                (req.getHeader("X-Event-Key").equalsIgnoreCase("pullrequest:created") ||
+                        req.getHeader("X-Event-Key").equalsIgnoreCase("pullrequest:updated"));
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(BitbucketWebhookListener.class.getName());
+}

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketWebhookListener.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketWebhookListener.java
@@ -1,6 +1,8 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValue;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BitbucketPullRequestResponseValueRepositoryRepository;
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.UnprotectedRootAction;
@@ -21,9 +23,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -50,12 +50,16 @@ public class BitbucketWebhookListener  implements UnprotectedRootAction {
                 body = body.substring(8);
             }
 
-            LOGGER.log(Level.WARNING, "Received hook notification : {0}", body);
+            LOGGER.log(Level.INFO, "Received hook notification : {0}", body);
 
             if (isPullRequestCreateOrUpdate(req)) {
                 JSONObject payload = JSONObject.fromObject(body);
 
-                triggerAppropriateBuild(req, payload);
+                triggerBuildForPullRequest(payload);
+            } else if (isPush(req)) {
+                JSONObject payload = JSONObject.fromObject(body);
+
+                triggerBuildForDestinationBranchPush(payload);
             }
 
         } else {
@@ -64,13 +68,18 @@ public class BitbucketWebhookListener  implements UnprotectedRootAction {
 
     }
 
+    private static boolean isPush(StaplerRequest req) {
+        return req.getHeader("User-Agent").equalsIgnoreCase("Bitbucket-Webhooks/2.0") &&
+                req.getHeader("X-Event-Key").equalsIgnoreCase("repo:push");
+    }
+
     private static boolean isPullRequestCreateOrUpdate(HttpServletRequest req) {
         return req.getHeader("User-Agent").equalsIgnoreCase("Bitbucket-Webhooks/2.0") &&
                 (req.getHeader("X-Event-Key").equalsIgnoreCase("pullrequest:created") ||
                         req.getHeader("X-Event-Key").equalsIgnoreCase("pullrequest:updated"));
     }
 
-    private static void triggerAppropriateBuild(HttpServletRequest req, JSONObject payload) {
+    private static void triggerBuildForPullRequest(JSONObject payload) {
         try {
             BitbucketPullRequestResponseValue pullRequest = createPullRequestFromJson(payload);
 
@@ -86,10 +95,86 @@ public class BitbucketWebhookListener  implements UnprotectedRootAction {
         }
     }
 
+    private static void triggerBuildForDestinationBranchPush(JSONObject payload) {
+        Set<String> destinationBranches = getDestinationBranches(payload);
+
+        LOGGER.log(Level.FINE, "Destination branches for push: {0}", destinationBranches);
+
+        if (!destinationBranches.isEmpty()) {
+            try {
+                BitbucketPullRequestResponseValueRepositoryRepository repository = createRepositoryFromJson(payload);
+                HashSet<String> pullRequestsBuilt = new HashSet<String>();
+
+                for (Job<?,?> job : getAllJobs()) {
+                    if (repositoryMatches(repository.getLinks().getHtml().getHref(), job)) {
+
+                        LOGGER.log(Level.FINE, "Push repository matches job: {0}", job.getName());
+
+                        for (BitbucketBuildTrigger trigger : getBitBucketTriggers(job)) {
+                            if (trigger.getCheckDestinationCommit()) {
+                                for (BitbucketPullRequestResponseValue pullRequest : getOpenPullRequests(trigger)) {
+
+                                    LOGGER.log(Level.INFO, "Evaluating open pull request: {0}", pullRequest.getTitle());
+
+                                    if (!isSkipBuild(pullRequest.getTitle(), trigger) &&
+                                            destinationBranches.contains(pullRequest.getDestination().getBranch().getName()) &&
+                                            pullRequestsBuilt.add(pullRequest.getLinks().getSelf().getHref())) {
+                                        trigger.getBuilder().runPullRequestBuild(pullRequest);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Could not parse JSON for repo push (" + e.getMessage() + "):\n" + payload.toString(4));
+            }
+        }
+    }
+
+    private static Set<String> getDestinationBranches(JSONObject repositoryPushPayload) {
+        HashSet<String> destinationBranches = new HashSet<String>();
+
+        for (Object obj:repositoryPushPayload.getJSONObject("push")
+                .getJSONArray("changes")) {
+            if (obj instanceof JSONObject) {
+                JSONObject change = (JSONObject)obj;
+
+                if (change.has("new"))
+                {
+                    JSONObject newState = change.getJSONObject("new");
+
+                    if (newState.getString("type").equals("branch")) {
+                        destinationBranches.add(newState.getString("name"));
+                    }
+                }
+            }
+        }
+
+        return destinationBranches;
+    }
+
+    private static List<Job> getAllJobs() {
+        return Jenkins.getInstance().getAllItems(Job.class);
+    }
+
+    private static Iterable<? extends BitbucketPullRequestResponseValue> getOpenPullRequests(BitbucketBuildTrigger trigger) {
+        BitbucketApiClient apiClient = new BitbucketApiClient(trigger.getUsername(), trigger.getPassword(), trigger.getRepositoryOwner(), trigger.getRepositoryName());
+        ArrayList<BitbucketPullRequestResponseValue> pullRequests = new ArrayList<BitbucketPullRequestResponseValue>();
+
+        for (BitbucketPullRequestResponseValue pullRequest : apiClient.getPullRequests()) {
+            if (pullRequest.getState().equalsIgnoreCase("open")) {
+                pullRequests.add(pullRequest);
+            }
+        }
+
+        return pullRequests;
+    }
+
     private static Collection<BitbucketBuildTrigger> findTriggersMatchingPullRequest(BitbucketPullRequestResponseValue pullRequest) {
         List<BitbucketBuildTrigger> triggers = new ArrayList<BitbucketBuildTrigger>();
 
-        for (Job<?,?> job : Jenkins.getInstance().getAllItems(Job.class)) {
+        for (Job<?,?> job : getAllJobs()) {
             if(repositoryMatches(pullRequest, job)) {
                 for (BitbucketBuildTrigger trigger : getBitBucketTriggers(job)) {
                     if (!isSkipBuild(pullRequest.getTitle(), trigger)) {
@@ -103,15 +188,19 @@ public class BitbucketWebhookListener  implements UnprotectedRootAction {
     }
 
     private static Boolean repositoryMatches(BitbucketPullRequestResponseValue pullRequest, Job<?, ?> job) {
-        SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
+        return repositoryMatches(pullRequest.getDestination().getRepository().getLinks().getHtml().getHref(), job);
+    }
 
+    private static Boolean repositoryMatches(String gitRepositoryUri, Job<?, ?> job) {
         try {
-            URIish gitRemote = new URIish(pullRequest.getDestination().getRepository().getLinks().getHtml().getHref());
+            URIish gitRepository = new URIish(gitRepositoryUri);
+            SCMTriggerItem item = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
+
             for (SCM scmTrigger : item.getSCMs()) {
                 if (scmTrigger instanceof GitSCM) {
                     for (RemoteConfig remoteConfig : ((GitSCM) scmTrigger).getRepositories()) {
                         for (URIish urIish : remoteConfig.getURIs()) {
-                            if (GitStatus.looselyMatches(urIish, gitRemote)) {
+                            if (GitStatus.looselyMatches(urIish, gitRepository)) {
                                 return true;
                             }
                         }
@@ -142,6 +231,17 @@ public class BitbucketWebhookListener  implements UnprotectedRootAction {
         LOGGER.log(Level.FINE, "Found {0} applicable triggers", triggers.size());
 
         return triggers;
+    }
+
+    private static BitbucketPullRequestResponseValueRepositoryRepository createRepositoryFromJson(JSONObject payload) throws IOException {
+        JSONObject repositoryJson = payload.getJSONObject("repository");
+
+        if (repositoryJson == null) {
+            throw new IOException("Did not find repository object in payload.");
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(repositoryJson.toString(), BitbucketPullRequestResponseValueRepositoryRepository.class);
     }
 
     private static BitbucketPullRequestResponseValue createPullRequestFromJson(JSONObject payload) throws IOException {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValue.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValue.java
@@ -20,6 +20,15 @@ public class BitbucketPullRequestResponseValue {
     private String updatedOn;
     private String mergeCommit;
     private String id;
+    private BitbucketPullRequestResponseValueLinks links;
+
+    public BitbucketPullRequestResponseValueLinks getLinks() {
+        return links;
+    }
+
+    public void setLinks(BitbucketPullRequestResponseValueLinks links) {
+        this.links = links;
+    }
 
     public String getDescription() {
         return description;

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLink.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLink.java
@@ -1,0 +1,10 @@
+package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+/**
+ * Created by charles on 10/24/15.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketPullRequestResponseValueLink {
+}

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLink.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLink.java
@@ -7,4 +7,9 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketPullRequestResponseValueLink {
+    private String href;
+
+    public String getHref() { return this.href; }
+
+    public void setHref(String href) { this.href = href; }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLinks.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLinks.java
@@ -8,7 +8,6 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketPullRequestResponseValueLinks {
     private BitbucketPullRequestResponseValueLink html;
-    private BitbucketPullRequestResponseValueLink avatar;
     private BitbucketPullRequestResponseValueLink self;
 
     public BitbucketPullRequestResponseValueLink getSelf() {
@@ -17,14 +16,6 @@ public class BitbucketPullRequestResponseValueLinks {
 
     public void setSelf(BitbucketPullRequestResponseValueLink self) {
         this.self = self;
-    }
-
-    public BitbucketPullRequestResponseValueLink getAvatar() {
-        return avatar;
-    }
-
-    public void setAvatar(BitbucketPullRequestResponseValueLink avatar) {
-        this.avatar = avatar;
     }
 
     public BitbucketPullRequestResponseValueLink getHtml() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLinks.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLinks.java
@@ -1,0 +1,10 @@
+package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+/**
+ * Created by charles on 10/24/15.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketPullRequestResponseValueLinks {
+}

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLinks.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueLinks.java
@@ -7,4 +7,31 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketPullRequestResponseValueLinks {
+    private BitbucketPullRequestResponseValueLink html;
+    private BitbucketPullRequestResponseValueLink avatar;
+    private BitbucketPullRequestResponseValueLink self;
+
+    public BitbucketPullRequestResponseValueLink getSelf() {
+        return self;
+    }
+
+    public void setSelf(BitbucketPullRequestResponseValueLink self) {
+        this.self = self;
+    }
+
+    public BitbucketPullRequestResponseValueLink getAvatar() {
+        return avatar;
+    }
+
+    public void setAvatar(BitbucketPullRequestResponseValueLink avatar) {
+        this.avatar = avatar;
+    }
+
+    public BitbucketPullRequestResponseValueLink getHtml() {
+        return html;
+    }
+
+    public void setHtml(BitbucketPullRequestResponseValueLink html) {
+        this.html = html;
+    }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueRepositoryRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueRepositoryRepository.java
@@ -7,6 +7,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 public class BitbucketPullRequestResponseValueRepositoryRepository {
     private String fullName;
     private String name;
+    private String scm;
 
     @JsonProperty("full_name")
     public String getFullName() {
@@ -25,6 +26,10 @@ public class BitbucketPullRequestResponseValueRepositoryRepository {
     public void setName(String name) {
         this.name = name;
     }
+
+    public String getScm() { return this.scm; }
+
+    public void setScm(String scm) { this.scm = scm; }
 
     public String getOwnerName() {
         if (this.fullName != null) {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueRepositoryRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketPullRequestResponseValueRepositoryRepository.java
@@ -8,6 +8,15 @@ public class BitbucketPullRequestResponseValueRepositoryRepository {
     private String fullName;
     private String name;
     private String scm;
+    private BitbucketPullRequestResponseValueLinks links;
+
+    public BitbucketPullRequestResponseValueLinks getLinks() {
+        return links;
+    }
+
+    public void setLinks(BitbucketPullRequestResponseValueLinks links) {
+        this.links = links;
+    }
 
     @JsonProperty("full_name")
     public String getFullName() {

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -1,7 +1,4 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:entry title="Cron" field="cron">
-    <f:textbox />
-  </f:entry>
   <f:entry title="Bitbucket BasicAuth Username" field="username">
     <f:textbox />
   </f:entry>


### PR DESCRIPTION
Reworked the plugin to trigger based on Bitbucket Webhooks rather than a cron job.  Also supports rebuilding when a pull request is updated.

Should address:
- [JENKINS-30277](https://issues.jenkins-ci.org/browse/JENKINS-30277)
- [JENKINS-26786](https://issues.jenkins-ci.org/browse/JENKINS-26786)
- [JENKINS-26785](https://issues.jenkins-ci.org/browse/JENKINS-26785)

Might address (not tested):
- [JENKINS-29919](https://issues.jenkins-ci.org/browse/JENKINS-29919)
