### PR TITLE
Use the 2.0 Bitbucket pull request comment API. 

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
@@ -2,6 +2,7 @@ package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
 
 import java.util.List;
 import java.util.Comparator;
+import java.util.Map;
 
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -31,11 +32,12 @@ public class Pullrequest {
     private Author     author;
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Response {
+    public static class Response<T> {
         private int pageLength;
-        private List<Pullrequest> pullrequests;
+        private List<T> values;
         private int page;
         private int size;
+        private String next;
 
         @JsonProperty("pagelen")
         public int getPageLength() {
@@ -45,13 +47,11 @@ public class Pullrequest {
         public void setPageLength(int pageLength) {
             this.pageLength = pageLength;
         }
-        @JsonProperty("values")
-        public List<Pullrequest> getPullrequests() {
-            return pullrequests;
+        public List<T> getValues() {
+            return values;
         }
-        @JsonProperty("values")
-        public void setPullrequests(List<Pullrequest> pullrequests) {
-            this.pullrequests = pullrequests;
+        public void setValues(List<T> values) {
+            this.values = values;
         }
         public int getPage() {
             return page;
@@ -65,7 +65,14 @@ public class Pullrequest {
         public void setSize(int size) {
             this.size = size;
         }
+        public String getNext() {
+            return next;
+        }
+        public void setNext(String next) {
+            this.next = next;
+        }
     }
+
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Revision {
@@ -214,8 +221,13 @@ public class Pullrequest {
             return content;
         }
 
-        public void setContent(String content) {
-            this.content = content;
+        public void setContent(Object content) {
+            if (content instanceof String) {
+                this.content = (String)content;
+            } else if (content instanceof Map){
+                this.content = (String)((Map)content).get("raw");
+            }
+            return;
         }
         @JsonProperty("utc_last_updated")
         public String getUpdatedOn() {


### PR DESCRIPTION
I'm a developer on the Bitbucket team. The 1.0 pull request comment API is deprecated, and for historical reasons is a fairly expensive API call for us. This PR replaces the call with a call to the 2.0 API pull request comment API. We don't currently have all pull request comment functionality available in the 2.0 API, so the posting and editing of comments should continue to be done using the 1.0 API.

All Bitbucket 2.0 APIs are paginated. While converting the comments API I noticed that while the plugin is using the 2.0 pull requests API, it's only grabbing the first page of results, so I fixed that as well.

Since in both cases the plugin wants all available values, I added the maximum allowed pagelen header for each API which should reduce the number of calls that should need to be made to get a complete list.
