### PR TITLE
Add option to cancel outdated builds when a pull request is updated

### DIFF
--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -38,4 +38,7 @@
   <f:entry title="Approve if build success?" field="approveIfSuccess">
     <f:checkbox />
   </f:entry>
+  <f:entry title="Cancel outdated jobs?" field="cancelOutdatedJobs">
+    <f:checkbox default="false"/>
+  </f:entry>
 </j:jelly>

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -118,7 +118,8 @@ public class BitbucketBuildRepositoryTest {
       "", true,
       "", "", "",
       true, 
-      true
+      true,
+      false
     );
     
     BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
@@ -148,7 +149,8 @@ public class BitbucketBuildRepositoryTest {
       "", true,
       "", "", "",
       true, 
-      true
+      true,
+      false
     );          
     
     BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
@@ -202,7 +204,8 @@ public class BitbucketBuildRepositoryTest {
       "", true,
       "jenkins", "Jenkins", "",
       true, 
-      true
+      true,
+      false
     );
     
     BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
@@ -248,7 +251,8 @@ public class BitbucketBuildRepositoryTest {
       "", true,
       "jenkins-too-long-ci-key", "Jenkins", "",
       true, 
-      true
+      true,
+      false
     );
     
     final MessageDigest MD5 = MessageDigest.getInstance("MD5");


### PR DESCRIPTION
It was always a complaint in my team that builds were not cancelled or removed from the queue when they update a pull request. This pull request therefore adds that feature.
