### PR TITLE
Fix `null/null` repository URL

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
@@ -114,7 +114,7 @@ public class Pullrequest {
         @JsonProperty("full_name")
         public void setFullName(String fullName) {
             // Also extract owner- and reponame
-            if (name != null) {
+            if (fullName != null) {
                 this.ownerName = fullName.split("/")[0];
                 this.repositoryName = fullName.split("/")[1];
             }


### PR DESCRIPTION
On the latest version I started getting these errors in the logs and my jobs would trigger every minute and never flag the build as having run before.

```
POST state INPROGRESS to https://bitbucket.org/api/2.0/repositories/null/null/commit/b6f8169ce460/statuses/build with key 515f53a20bf37bd484f2be5cda6ab168cd194cee with response {"type": "error", "error": {"message": "Repository null/null not found"}}
```

Functionality in `getOwnerName` and `getRepositoryName` name changed from previous versions, moved to inside `setFullName` which is now doing the `if` on the wrong value. This causes `null/null` to be set as the owner name / repo name.