### PR TITLE
Upgrading parent pom org.jenkins-ci.plugins to version 2.11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.596.1</version>
+    <version>2.11</version>
   </parent>
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildFilter.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildFilter.java
@@ -1,6 +1,5 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
-import hudson.model.Action;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.ArrayList;
@@ -114,7 +113,7 @@ class SourceDestFlag extends Filter {
 class AuthorFlag extends Filter {
   static final Pattern AUTHOR_MATCHER_RX = Pattern.compile(AUTHOR_RX + BRANCH_FILTER_RX_PART, Pattern.CASE_INSENSITIVE | Pattern.CANON_EQ);
   
-  class AuthorFlagImpl extends Filter {
+  static class AuthorFlagImpl extends Filter {
     @Override
     public boolean apply(String filter, BitbucketCause cause) { 
       String selectedRx = filter.startsWith(RX_FILTER_FLAG_SINGLE) ? filter.substring(RX_FILTER_FLAG_SINGLE.length()) : Pattern.quote(filter);
@@ -204,30 +203,30 @@ public class BitbucketBuildFilter {
     return this.currFilter.apply(this.filter, cause);
   }  
   
-  public static BitbucketBuildFilter InstanceByString(String filter) {
+  public static BitbucketBuildFilter instanceByString(String filter) {
     logger.log(Level.INFO, "Filter instance by filter string");
     return new BitbucketBuildFilter(filter);
   }    
   
-  static public String FilterFromGitSCMSource(AbstractGitSCMSource gitscm, String defaultFilter) {
+  static public String filterFromGitSCMSource(AbstractGitSCMSource gitscm, String defaultFilter) {
     if (gitscm == null) {
       logger.log(Level.INFO, "Git SCMSource unavailable. Using default value: {0}", defaultFilter);
       return defaultFilter;
     }
 
-    String filter = defaultFilter;
+    StringBuffer filter = new StringBuffer(defaultFilter);
     final String includes = gitscm.getIncludes();
     if (includes != null && !includes.isEmpty()) {
       for(String part : includes.split("\\s+")) {
-        filter += String.format("%s ", part.replaceAll("\\*\\/", "d:"));
+        filter.append(String.format("%s ", part.replaceAll("\\*\\/", "d:")));
       }
     }    
     
     logger.log(Level.INFO, "Git includes transformation to filter result: {1} -> {0}; default: {2}", new Object[]{ filter, includes, defaultFilter });
-    return filter.trim();
+    return filter.toString().trim();
   }
   
-  public static BitbucketBuildFilter InstanceBySCM(Collection<SCMSource> scmSources, String defaultFilter) {      
+  public static BitbucketBuildFilter instanceBySCM(Collection<SCMSource> scmSources, String defaultFilter) {
     logger.log(Level.INFO, "Filter instance by using SCMSources list with {0} items", scmSources.size());
     AbstractGitSCMSource gitscm = null;
     for(SCMSource scm : scmSources) {
@@ -237,6 +236,6 @@ public class BitbucketBuildFilter {
         break;
       }
     }    
-    return new BitbucketBuildFilter(FilterFromGitSCMSource(gitscm, defaultFilter));
+    return new BitbucketBuildFilter(filterFromGitSCMSource(gitscm, defaultFilter));
   }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -120,10 +120,19 @@ public class BitbucketRepository {
                     pullRequest.getDestination().getCommit().getHash(),
                     pullRequest.getAuthor().getCombinedUsername()
             );
-            setBuildStatus(cause, BuildState.INPROGRESS, Jenkins.getInstance().getRootUrl());
+            setBuildStatus(cause, BuildState.INPROGRESS, getInstance().getRootUrl());
             this.builder.getTrigger().startJob(cause);
         }
     }
+
+    private Jenkins getInstance() {
+        final Jenkins instance = Jenkins.getInstance();
+        if (instance == null){
+            throw new IllegalStateException("Jenkins instance is NULL!");
+        }
+        return instance;
+    }
+
 
     public void setBuildStatus(BitbucketCause cause, BuildState state, String buildUrl) {
         String comment = null;
@@ -295,8 +304,8 @@ public class BitbucketRepository {
             sources.add(src);                
         
         BitbucketBuildFilter filter = !this.trigger.getBranchesFilterBySCMIncludes() ? 
-          BitbucketBuildFilter.InstanceByString(this.trigger.getBranchesFilter()) :
-          BitbucketBuildFilter.InstanceBySCM(sources, this.trigger.getBranchesFilter());
+          BitbucketBuildFilter.instanceByString(this.trigger.getBranchesFilter()) :
+          BitbucketBuildFilter.instanceBySCM(sources, this.trigger.getBranchesFilter());
         
         return filter.approved(cause);
     }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -58,7 +58,7 @@ public class ApiClient {
 
             if (Jenkins.getInstance() == null) return client;
 
-            ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+            ProxyConfiguration proxy = getInstance().proxy;
             if (proxy == null) return client;
 
             logger.log(Level.INFO, "Jenkins proxy: {0}:{1}", new Object[]{ proxy.name, proxy.port });
@@ -75,7 +75,17 @@ public class ApiClient {
             
             return client;
         }
+
+        private Jenkins getInstance() {
+            final Jenkins instance = Jenkins.getInstance();
+            if (instance == null){
+                throw new IllegalStateException("Jenkins instance is NULL!");
+            }
+            return instance;
+        }
     }
+
+
     
     public <T extends HttpClientFactory> ApiClient(
         String username, String password, 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
@@ -199,6 +199,21 @@ public class Pullrequest {
             }
         }
 
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            final Comment comment = (Comment) o;
+
+            return getId() != null ? getId().equals(comment.getId()) : comment.getId() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return getId() != null ? getId().hashCode() : 0;
+        }
+
         @JsonProperty("comment_id")
         public Integer getId() {
             return id;

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="Cron" field="cron">
     <f:textbox />

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/test/java/BitbucketBuildFilterTest.java
+++ b/src/test/java/BitbucketBuildFilterTest.java
@@ -45,12 +45,12 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(cause);
       
     for(String f : new String[] {"", "*", "any"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertTrue(filter.approved(cause));
     }
     
     for(String f : new String[] {"foo", "bar", " baz "}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertFalse(filter.approved(cause));
     }
   }
@@ -63,12 +63,12 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(cause);
     
     for(String f : new String[] {"master-branch", "r:^master", "r:branch$", " master-branch "}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertTrue(filter.approved(cause));
     }
     
     for(String f : new String[] {"develop", "feature-good-thing", "r:develop$"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertFalse(filter.approved(cause));
     }
   }
@@ -92,12 +92,12 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(cause);
     
     for(String f : new String[] {"s:feature-for-master d:master", "s:r:^feature d:master", "s:feature-for-master d:r:^m", "s:r:^feature d:r:^master"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertTrue(filter.approved(cause));
     }
     
     for(String f : new String[] {"s:feature-for-master d:foo", "s:bar d:master", "s:foo d:bar"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertFalse(filter.approved(cause));
     }
   }
@@ -111,12 +111,12 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(cause);
     
     for(String f : new String[] {"s: d:", "s:r:^feature s:good-branch d:r:.*", "s:good-branch s:feature-master d:r:.*", "s: d:r:.*", "d:master d:foo d:bar s:"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertTrue(filter.approved(cause));
     }
     
     for(String f : new String[] {"d:ggg d:ooo d:333 s:feature-master", "s:111 s:222 s:333 d:master"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertFalse(filter.approved(cause));
     }
   }
@@ -130,12 +130,12 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(cause);
     
     for(String f : new String[] {"s:feature-master d:", "d:master s:"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertTrue(filter.approved(cause));
     }
     
     for(String f : new String[] {"s:feature-master", "d:master"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertFalse(filter.approved(cause));
     }
   }
@@ -150,12 +150,12 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(cause);
     
     for(String f : new String[] {"a:test", "a:r:^test", "d: s: a:", "a:", "a:foo a:test"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertTrue(filter.approved(cause));
     }
     
     for(String f : new String[] {"s:feature-master", "d:master", "s:feature-master d: a:foo", "a:bar"}) {
-      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      BitbucketBuildFilter filter = BitbucketBuildFilter.instanceByString(f);
       assertFalse(filter.approved(cause));
     }
   }
@@ -167,11 +167,11 @@ public class BitbucketBuildFilterTest {
     EasyMock.expect(cause.getTargetBranch()).andReturn("master").anyTimes();
     EasyMock.replay(cause);
     
-    assertTrue(BitbucketBuildFilter.FilterFromGitSCMSource(null, "").isEmpty());
-    assertEquals("default", BitbucketBuildFilter.FilterFromGitSCMSource(null, "default"));
+    assertTrue(BitbucketBuildFilter.filterFromGitSCMSource(null, "").isEmpty());
+    assertEquals("default", BitbucketBuildFilter.filterFromGitSCMSource(null, "default"));
     
-    assertTrue(BitbucketBuildFilter.InstanceByString(
-      BitbucketBuildFilter.FilterFromGitSCMSource(null, "")).approved(cause)
+    assertTrue(BitbucketBuildFilter.instanceByString(
+      BitbucketBuildFilter.filterFromGitSCMSource(null, "")).approved(cause)
     );
   }
   
@@ -187,9 +187,9 @@ public class BitbucketBuildFilterTest {
     EasyMock.replay(git);
     
     assertTrue(git.getIncludes().isEmpty());    
-    assertEquals("", BitbucketBuildFilter.FilterFromGitSCMSource(git, ""));
-    assertEquals("d:master d:feature-branch", BitbucketBuildFilter.FilterFromGitSCMSource(git, ""));
-    assertEquals("d:master", BitbucketBuildFilter.FilterFromGitSCMSource(git, ""));
+    assertEquals("", BitbucketBuildFilter.filterFromGitSCMSource(git, ""));
+    assertEquals("d:master d:feature-branch", BitbucketBuildFilter.filterFromGitSCMSource(git, ""));
+    assertEquals("d:master", BitbucketBuildFilter.filterFromGitSCMSource(git, ""));
   }
   
   @Test


### PR DESCRIPTION
I failed releasing version 1.4.20 due to outdated parent pom. It tries to upload to maven.jenkins-ci.org which is no longer available
Stacktrace:
 Caused by: org.apache.maven.wagon.providers.http.httpclient.conn.HttpHostConnectException: Connect to maven.jenkins-ci.org:8081 [maven.jenkins-ci.org/199.193.196.24] failed: Operation timed out

More details
https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins#HostingPlugins-Workingaroundcommonissues