### PR TITLE
setBuildStatus broken for cloud

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -1,6 +1,5 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
 
-import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.server.ServerPullrequest;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.httpclient.*;
 import org.apache.commons.httpclient.auth.AuthScope;
@@ -213,18 +212,6 @@ public abstract class ApiClient {
     }
     protected <R> R parse(String response, TypeReference<R> ref) throws IOException {
         return new ObjectMapper().readValue(response, ref);
-    }
-
-    protected void setBuildStatus(BuildState state, String buildUrl, String comment, String keyEx, String url) {
-        String computedKey = computeAPIKey(keyEx);
-        ServerPullrequest.CommitBuildState commit = new ServerPullrequest.CommitBuildState();
-        commit.setKey(computedKey);
-        commit.setState(state);
-        commit.setUrl(buildUrl);
-
-        logger.log(Level.FINE, "POST state {0} to {1} with key {2} with response {3}", new Object[]{
-            state, url, computedKey, post(url, commit)}
-        );
     }
 
     public abstract <T extends AbstractPullrequest> List<T> getPullRequests();

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudApiClient.java
@@ -52,13 +52,28 @@ public class CloudApiClient extends ApiClient {
     public boolean hasBuildStatus(String owner, String repositoryName, String revision, String keyEx) {
         String url = v2(owner, repositoryName, "/commit/" + revision + "/statuses/build/" + computeAPIKey(keyEx));
         String reqBody = get(url);
+        logger.log(Level.FINE, "hasBuildStatus response: " + reqBody);
         return reqBody != null && reqBody.contains("\"state\"");
     }
 
     @Override
     public void setBuildStatus(String owner, String repositoryName, String revision, BuildState state, String buildUrl, String comment, String keyEx) {
         String url = v2(owner, repositoryName, "/commit/" + revision + "/statuses/build");
-        setBuildStatus(state, buildUrl, comment, keyEx, url);
+        String computedKey = this.computeAPIKey(keyEx);
+
+        NameValuePair[] data = new NameValuePair[]{
+                new NameValuePair("description", comment),
+                new NameValuePair("key", computedKey),
+                new NameValuePair("name", this.name),
+                new NameValuePair("state", state.toString()),
+                new NameValuePair("url", buildUrl),
+        };
+
+        String resp = post(url, data);
+
+        logger.log(Level.FINE, "POST state {0} to {1} with key {2} with response {3}", new Object[]{
+          state, url, computedKey, resp}
+        );
     }
 
     @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerApiClient.java
@@ -64,7 +64,21 @@ public class ServerApiClient extends ApiClient {
 
     @Override
     public void setBuildStatus(String owner, String repositoryName, String revision, BuildState state, String buildUrl, String comment, String keyEx) {
-        setBuildStatus(state, buildUrl, comment, keyEx, buildStateV1(revision));
+        String url = buildStateV1(revision);
+        String computedKey = computeAPIKey(keyEx);
+        ServerPullrequest.CommitBuildState commit = new ServerPullrequest.CommitBuildState();
+
+        // FIXME TODO WTF? Where do you put the comment?
+
+        commit.setKey(computedKey);
+        commit.setState(state);
+        commit.setUrl(buildUrl);
+
+        String resp = post(url, commit);
+
+        logger.log(Level.FINE, "POST state {0} to {1} with key {2} with response {3}", new Object[]{
+            state, url, computedKey, resp}
+        );
     }
 
     @Override


### PR DESCRIPTION

When support for Bitbucket Server was added, the setBuildStatus function was accidentally broken, and started ONLY working for Server.

This change fixes the abstraction, and separates out setBuildStatus for Cloud and Server appropriately. (I used the old Cloud code, pre server, to re-implement the v2 Cloud endpoint for setBuildStatus)

