### PR TITLE
Use GitHub as a source of the plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <version>1.5.1-SNAPSHOT</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>    
+  <url>https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin</url>    
 
   <scm>
     <connection>scm:git:ssh://git@github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git</connection>


### PR DESCRIPTION
FTR https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/ , now the documentation can be retrieved from GitHub directly. Wiki is in the read-only state.

A release will be required to get this change applied